### PR TITLE
Mocha wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-jest-snapshot",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Chai assertion that provides Jest's snapshot testing",
   "main": "dist/index.js",
   "repository": "https://github.com/suchipi/chai-jest-snapshot",

--- a/src/buildMatchSnapshot.js
+++ b/src/buildMatchSnapshot.js
@@ -1,57 +1,13 @@
-import path from "path";
-import SnapshotFile from "./SnapshotFile";
-import values from "lodash.values";
+import rawMatchSnapshot from "./matchSnapshot";
 
 const buildMatchSnapshot = (utils) => {
   const snapshotFiles = {};
-
   return function matchSnapshot(snapshotFileName, snapshotName, update) {
     if (utils.flag(this, 'negate')) {
       throw new Error("`matchSnapshot` cannot be used with `.not`.");
     }
-
-    const obj = this._obj;
-    const absolutePathToSnapshot = path.resolve(snapshotFileName);
-    let snapshotFile;
-    if (snapshotFiles[absolutePathToSnapshot]) {
-      snapshotFile = snapshotFiles[absolutePathToSnapshot];
-    } else {
-      snapshotFiles[absolutePathToSnapshot] = new SnapshotFile(absolutePathToSnapshot);
-      snapshotFile = snapshotFiles[absolutePathToSnapshot];
-    }
-
-    if (this._publishInternalVariableForTesting) {
-      this._publishInternalVariableForTesting("snapshotFile", snapshotFile);
-    }
-
-    let matches;
-    let pass;
-
-    if (snapshotFile.fileExists() && snapshotFile.has(snapshotName)) {
-      matches = snapshotFile.matches(snapshotName, obj);
-      pass = matches.pass;
-    } else {
-      snapshotFile.add(snapshotName, obj);
-      snapshotFile.save();
-      pass = true;
-    }
-
-    const shouldUpdate = update || (typeof process !== "undefined" && process.env && process.env.CHAI_JEST_SNAPSHOT_UPDATE_ALL);
-
-    if (!pass && shouldUpdate) {
-      snapshotFile.add(snapshotName, obj);
-      snapshotFile.save();
-      pass = true;
-    }
-
-    this.assert(
-      pass,
-      `expected value to match snapshot ${snapshotName}`,
-      `expected value to not match snapshot ${snapshotName}`,
-      matches && matches.expected && matches.expected.trim(),
-      matches && matches.actual && matches.actual.trim(),
-      matches && true
-    )
+    
+    rawMatchSnapshot.apply(this, [snapshotFiles, snapshotFileName, snapshotName, update]);
   };
 };
 

--- a/src/matchSnapshot.js
+++ b/src/matchSnapshot.js
@@ -1,0 +1,48 @@
+import path from "path";
+import SnapshotFile from "./SnapshotFile";
+import values from "lodash.values";
+
+export default function matchSnapshot(snapshotFiles, snapshotFileName, snapshotName, update) {
+    const obj = this._obj;
+    const absolutePathToSnapshot = path.resolve(snapshotFileName);
+    let snapshotFile;
+    if (snapshotFiles[absolutePathToSnapshot]) {
+        snapshotFile = snapshotFiles[absolutePathToSnapshot];
+    } else {
+        snapshotFiles[absolutePathToSnapshot] = new SnapshotFile(absolutePathToSnapshot);
+        snapshotFile = snapshotFiles[absolutePathToSnapshot];
+    }
+
+    if (this._publishInternalVariableForTesting) {
+        this._publishInternalVariableForTesting("snapshotFile", snapshotFile);
+    }
+
+    let matches;
+    let pass;
+
+    if (snapshotFile.fileExists() && snapshotFile.has(snapshotName)) {
+        matches = snapshotFile.matches(snapshotName, obj);
+        pass = matches.pass;
+    } else {
+        snapshotFile.add(snapshotName, obj);
+        snapshotFile.save();
+        pass = true;
+    }
+
+    const shouldUpdate = update || (typeof process !== "undefined" && process.env && process.env.CHAI_JEST_SNAPSHOT_UPDATE_ALL);
+
+    if (!pass && shouldUpdate) {
+        snapshotFile.add(snapshotName, obj);
+        snapshotFile.save();
+        pass = true;
+    }
+
+    this.assert(
+        pass,
+        `expected value to match snapshot ${snapshotName}`,
+        `expected value to not match snapshot ${snapshotName}`,
+        matches && matches.expected && matches.expected.trim(),
+        matches && matches.actual && matches.actual.trim(),
+        matches && true
+    )
+  };

--- a/src/mocha.js
+++ b/src/mocha.js
@@ -1,0 +1,7 @@
+import mochaBuildMatchSnapshot from "./mochaBuildMatchSnapshot";
+
+module.exports = function (context) {
+  return function (chai, utils) {
+    chai.Assertion.addMethod("matchSnapshot", mochaBuildMatchSnapshot(utils, context));
+  }
+}

--- a/src/mochaBuildMatchSnapshot.js
+++ b/src/mochaBuildMatchSnapshot.js
@@ -1,0 +1,41 @@
+import path from "path";
+import fs from "fs";
+import rawMatchSnapshot from "./matchSnapshot";
+
+const snapshotFiles = {};
+
+const buildMatchSnapshot = (utils, mochaContext) => {
+    const snapshots = {};
+
+    return function matchSnapshot(update) {
+        if (utils.flag(this, 'negate')) {
+            throw new Error("`matchSnapshot` cannot be used with `.not`.");
+        }
+        if (!mochaContext) {
+            throw new Error("Incorrect mocha context");
+        }
+        const filePath = mochaContext.file;
+        const title = mochaContext.title;
+        const ctx = mochaContext.ctx;
+        
+        // Track number of matchSnapshot() calls with same title
+        if (!snapshots[title]) {
+            snapshots[title] = 1;
+        } else {
+            snapshots[title]++;
+        }
+        
+        const SNAPSHOT_DIR_NAME = "__snapshots__";
+        const snapshotAbsoluteDir = path.join(path.dirname(filePath), SNAPSHOT_DIR_NAME);
+        if (!fs.existsSync(snapshotAbsoluteDir)) {
+            fs.mkdirSync(snapshotAbsoluteDir);
+        }
+        // Replace last extension with '.snap' rather than append it
+        const snapshotFileName = path.join(snapshotAbsoluteDir, path.basename(filePath, path.extname(filePath)) + ".snap");
+        const snapshotName = `${title} ${snapshots[title]}`;
+
+        rawMatchSnapshot.apply(this, [snapshotFiles, snapshotFileName, snapshotName, update]);
+    };
+};
+
+export default buildMatchSnapshot;


### PR DESCRIPTION
I'm not sure that this is correct way, but it greatly simplifies integration with mocha runner

testHelper.js
```js
const chaiJestSnapshot = require("chai-jest-snapshot/dist/mocha");
const chai = require("chai");
beforeEach(function () {
  chai.use(chaiJestSnapshot(this.currentTest));
});
```
test.js
```

it("snapshot title", () => {
  ...
  expect(tree).to.matchSnapshot();
  //or
  expect(tree).to.matchSnapshot(true); // to update
});
```

This will create ```__snapshot__``` directory in same directory and store snapshot as ```${basename}.snap```.
Snapshot name will be taken from test title, multiple ```matchSnapshot()``` calls in same test are supported too.

Original method ```matchSnapshot(path, name, update)``` should work too