### PR TITLE
reset Testname template when needed

### DIFF
--- a/src/buildConfigState.js
+++ b/src/buildConfigState.js
@@ -4,6 +4,7 @@ module.exports = function buildConfigState(determineConfig) {
   const config = {
     snapshotFilename: undefined,
     snapshotNameTemplate: undefined,
+    snapshotNameRegistry: {}, // snapshotNameRegistry[name] => number
   };
 
   function setFilename(snapshotFilename) {
@@ -12,6 +13,7 @@ module.exports = function buildConfigState(determineConfig) {
 
   function setTestName(snapshotNameTemplate) {
     config.snapshotNameTemplate = snapshotNameTemplate
+    config.snapshotNameRegistry[snapshotNameTemplate] = 0;
   }
 
   function configureUsingMochaContext(mochaContext) {
@@ -20,8 +22,7 @@ module.exports = function buildConfigState(determineConfig) {
     setTestName(currentTest.fullTitle());
   }
 
-  const snapshotNameRegistry = {}; // snapshotNameRegistry[filename][name] => number
-  const getNameForSnapshotUsingTemplate = buildGetNameForSnapshotUsingTemplate(snapshotNameRegistry);
+  const getNameForSnapshotUsingTemplate = buildGetNameForSnapshotUsingTemplate(config.snapshotNameRegistry);
 
   function parseArgs(args) {
     return determineConfig(args, config, getNameForSnapshotUsingTemplate);

--- a/src/buildGetNameForSnapshotUsingTemplate.js
+++ b/src/buildGetNameForSnapshotUsingTemplate.js
@@ -1,10 +1,7 @@
 module.exports = function buildGetNameForSnapshotUsingTemplate(snapshotNameRegistry) {
   return function getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate) {
-    if (snapshotNameRegistry[snapshotFilename] == null) {
-      snapshotNameRegistry[snapshotFilename] = {};
-    }
-    const nextCounter = (snapshotNameRegistry[snapshotFilename][snapshotNameTemplate] || 0) + 1;
-    snapshotNameRegistry[snapshotFilename][snapshotNameTemplate] = nextCounter;
+    const nextCounter = snapshotNameRegistry[snapshotNameTemplate] + 1;
+    snapshotNameRegistry[snapshotNameTemplate] = nextCounter;
 
     return `${snapshotNameTemplate} ${nextCounter}`;
   }

--- a/src/spec/getNameForSnapshotUsingTemplate.spec.js
+++ b/src/spec/getNameForSnapshotUsingTemplate.spec.js
@@ -11,61 +11,12 @@ describe("getNameForSnapshotUsingTemplate", function() {
   });
 
   const getNameForSnapshotUsingTemplate = (...args) => buildGetNameForSnapshotUsingTemplate(snapshotNameRegistry)(...args);
-  const expectRegistryCounter = (number) => expect(snapshotNameRegistry[snapshotFilename][snapshotNameTemplate]).to.equal(number);
-
-  describe("when the snapshot name registry is empty", function() {
-    it("appends a 1 to the name template", function() {
-      const result = getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate);
-      expect(result).to.equal("name 1");
-    });
-
-    it("updates the registry", function() {
-      getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate);
-      expectRegistryCounter(1);
-    });
-  });
-
-  describe("when the snapshot name registry has unrelated data", function() {
-    beforeEach(function() {
-      snapshotNameRegistry = {
-        someOtherFilename: {
-          someOtherName: 2,
-        },
-      };
-    });
-
-    it("appends a 1 to the name template", function() {
-      const result = getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate);
-      expect(result).to.equal("name 1");
-    });
-
-    it("updates the registry", function() {
-      getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate);
-      expectRegistryCounter(1);
-    });
-  });
-
-  describe("when the snapshot name registry has another file with the same snapshot name", function() {
-    beforeEach(function() {
-      snapshotNameRegistry = {
-        someOtherFilename: {
-          name: 2,
-        },
-      };
-    });
-
-    it("ignores it and (still) appends 1 to the name", function() {
-      const result = getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate);
-      expect(result).to.equal("name 1");
-    });
-  });
+  const expectRegistryCounter = (number) => expect(snapshotNameRegistry[snapshotNameTemplate]).to.equal(number);
 
   describe("when the snapshot name registry has data for the name already", function() {
     beforeEach(function() {
       snapshotNameRegistry = {
-        [snapshotFilename]: {
           [snapshotNameTemplate]: 3,
-        },
       };
     });
 

--- a/src/spec/matchSnapshot.spec.js
+++ b/src/spec/matchSnapshot.spec.js
@@ -242,4 +242,20 @@ describe("matchSnapshot", function() {
 
     it("the assertion passes", expectPass);
   });
+  /**
+    it("uses from #setTestname and auto-increases and reset auto-increase when setTestname is call again", function() {
+      const testedSnapshotNameTemplate = "SnapshotNameTemplate";
+      const operation = createMatchOperation();
+      buildMatchSnapshot.setTestname(testedSnapshotNameTemplate);
+      operation.run();
+      expect(operation.internal.snapshotFile[0]._content).to.have.keys(["SnapshotNameTemplate 1"]);
+      operation.run();
+      expect(operation.internal.snapshotFile[0]._content).to.have.length(2);
+      expect(operation.internal.snapshotFile[0]._content).to.have.keys(["SnapshotNameTemplate 2"]);
+      buildMatchSnapshot.setTestname(testedSnapshotNameTemplate);
+      operation.run();
+      expect(operation.internal.snapshotFile[0]._content).to.have.keys(["SnapshotNameTemplate 1"]);
+      expect(operation.internal.snapshotFile[0]._content).to.have.length(1);
+    });
+  */
 });


### PR DESCRIPTION
For `--watch` test (like `mocha` and `mocha-webpack`), current registry will not behave correctly. I have no idea how to test, though, but I already used this fork in our own (commercial) project.