### PR TITLE
Partial fix for issue #12 - not fixed for "manual mode"

### DIFF
--- a/src/buildConfigState.js
+++ b/src/buildConfigState.js
@@ -4,6 +4,7 @@ module.exports = function buildConfigState(determineConfig) {
   const config = {
     snapshotFilename: undefined,
     snapshotNameTemplate: undefined,
+    isNewRun: undefined,
   };
 
   function setFilename(snapshotFilename) {
@@ -12,6 +13,19 @@ module.exports = function buildConfigState(determineConfig) {
 
   function setTestName(snapshotNameTemplate) {
     config.snapshotNameTemplate = snapshotNameTemplate
+    _setIsNewRun();
+  }
+
+  /**
+   * isNewRun relates to whether the test suite is a new run or not. This is needed to track when
+   * a test runner runs in watch mode - we don't want to incremenet snapshots for every test run,
+   *  only incremenet within a run and reset for in the next run.
+   *  This function should only be called once per "it" test.
+   */
+  function _setIsNewRun() {
+    config.isNewRun = config.isNewRun || {};
+    config.isNewRun[config.snapshotFilename] = config.isNewRun[config.snapshotFilename] || {};
+    config.isNewRun[config.snapshotFilename][config.snapshotNameTemplate] = true;
   }
 
   function configureUsingMochaContext(mochaContext) {

--- a/src/buildGetNameForSnapshotUsingTemplate.js
+++ b/src/buildGetNameForSnapshotUsingTemplate.js
@@ -1,8 +1,14 @@
 module.exports = function buildGetNameForSnapshotUsingTemplate(snapshotNameRegistry) {
-  return function getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate) {
+  return function getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate, isNewRun = false, setIsNewRun) {
     if (snapshotNameRegistry[snapshotFilename] == null) {
       snapshotNameRegistry[snapshotFilename] = {};
     }
+
+    if (isNewRun) {
+      setIsNewRun(snapshotFilename, snapshotNameTemplate, false);
+      snapshotNameRegistry[snapshotFilename][snapshotNameTemplate] = 0;
+    }
+
     const nextCounter = (snapshotNameRegistry[snapshotFilename][snapshotNameTemplate] || 0) + 1;
     snapshotNameRegistry[snapshotFilename][snapshotNameTemplate] = nextCounter;
 

--- a/src/determineConfig.js
+++ b/src/determineConfig.js
@@ -21,7 +21,12 @@ module.exports = function determineConfig(args, config, getNameForSnapshotUsingT
 
   if (config.snapshotFilename && config.snapshotNameTemplate) {
     snapshotFilename = config.snapshotFilename;
-    snapshotName = getNameForSnapshotUsingTemplate(snapshotFilename, config.snapshotNameTemplate);
+    snapshotName = getNameForSnapshotUsingTemplate(
+      snapshotFilename,
+      config.snapshotNameTemplate,
+      config.isNewRun ? config.isNewRun[snapshotFilename][config.snapshotNameTemplate] : false,
+      (f, t, bool) => config.isNewRun[f][t] = bool
+    );
     update = args[0] || false;
   } else {
     if (args.length < 2) {

--- a/src/spec/determineConfig.spec.js
+++ b/src/spec/determineConfig.spec.js
@@ -175,6 +175,35 @@ describe("determineConfig", function() {
           update: true,
         },
       },
+      // with isNewRun
+      {
+        args: [false],
+        config: {
+          snapshotFilename: "filename",
+          snapshotNameTemplate: "name",
+          isNewRun: { 'filename': { 'name': true } }
+        },
+        envFlag: false,
+        expected: {
+          snapshotFilename: "filename",
+          snapshotName: getNameForSnapshotUsingTemplate("filename", "name", true),
+          update: false,
+        },
+      },
+      {
+        args: [false],
+        config: {
+          snapshotFilename: "filename",
+          snapshotNameTemplate: "name",
+          isNewRun: { 'filename': { 'name': false } }
+        },
+        envFlag: false,
+        expected: {
+          snapshotFilename: "filename",
+          snapshotName: getNameForSnapshotUsingTemplate("filename", "name", false),
+          update: false,
+        },
+      },
     ];
 
     examples.forEach((example) => {

--- a/src/spec/getNameForSnapshotUsingTemplate.spec.js
+++ b/src/spec/getNameForSnapshotUsingTemplate.spec.js
@@ -1,4 +1,5 @@
 import buildGetNameForSnapshotUsingTemplate from "../buildGetNameForSnapshotUsingTemplate";
+import { spy } from 'sinon';
 
 describe("getNameForSnapshotUsingTemplate", function() {
   let snapshotNameRegistry;
@@ -73,6 +74,20 @@ describe("getNameForSnapshotUsingTemplate", function() {
       const result = getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate);
       expect(result).to.equal("name 4");
       expectRegistryCounter(4);
+    });
+
+    it("doesn\'t add 1 to the value when `isNewRun` is true - returns name as if run for the first time", function() {
+      let setIsNewRun = spy();
+      let result = getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate, true, setIsNewRun);
+      expect(result).to.equal("name 1");
+      expectRegistryCounter(1);
+      expect(setIsNewRun.calledWith(snapshotFilename, snapshotNameTemplate, false)).to.be.ok;
+
+      setIsNewRun = spy();
+      result = getNameForSnapshotUsingTemplate(snapshotFilename, snapshotNameTemplate, false, setIsNewRun);
+      expect(result).to.equal("name 2");
+      expectRegistryCounter(2);
+      expect(setIsNewRun.called).not.to.be.ok;
     });
   });
 });


### PR DESCRIPTION
This PR addresses the issue I raised in #12 

Here I've introduced some state in config that tracks whether the current test run is new or not. If it is new then we reset the registry test counter else keep it as is. This prevents multiple snapshots for the same test being saved due to the tests running in watch mode.

This PR does not solve the problem in "manual mode" as we can't track when tests are re-run (no `beforeEach` hook). BUT this PR does solve the problem for the other modes in a backwards compatible way.