### PR TITLE
Expose addSerializer method from jest-snapshot

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import buildMatchSnapshot from "./buildMatchSnapshot";
 import buildConfigState from "./buildConfigState";
 import determineConfig from "./determineConfig";
+import { addSerializer } from "jest-snapshot";
 
 let hasChaiJestSnapshotBeenUsed = false;
 let configuredSetFilename;
@@ -63,5 +64,7 @@ chaiJestSnapshot.resetSnapshotRegistry = function resetSnapshotRegistry() {
     throw new Error("Please run `chai.use(chaiJestSnapshot)` before using `chaiJestSnapshot.resetSnapshotRegistry`.");
   }
 }
+
+chaiJestSnapshot.addSerializer = addSerializer;
 
 module.exports = chaiJestSnapshot;


### PR DESCRIPTION
This is useful for libraries like [enzyme-to-json](https://github.com/adriantoine/enzyme-to-json) to be able to be registered, thus avoiding explicit calls to `toJSON`.