### PR TITLE
Added support for Jest `--ci` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ $ env CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm test
 ```
 This behaves similarly to running `jest -u`.
 
-If you want to avoid updating snapshots and fail instead, set the environment variable `CHAI_JEST_CI` to "true":
+If you want to avoid updating snapshots and fail instead, set the environment variable `CI` to "true":
 ```shell
 # assuming `npm test` runs your tests:
 # sh/bash/zsh
-$ CHAI_JEST_CI=true npm test
+$ CI=true npm test
 # fish
-$ env CHAI_JEST_CI=true npm test
+$ env CI=true npm test
 ```
 This behaves similarly to running `jest --cli`.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ $ env CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm test
 ```
 This behaves similarly to running `jest -u`.
 
+If you want to avoid updating snapshots and fail instead, set the environment variable `CHAI_JEST_CI` to "true":
+```shell
+# assuming `npm test` runs your tests:
+# sh/bash/zsh
+$ CHAI_JEST_CI=true npm test
+# fish
+$ env CHAI_JEST_CI=true npm test
+```
+This behaves similarly to running `jest --cli`.
+
+
+
 ### Framework-agnostic Configuration Mode (Recommended for Non-Mocha Users)
 If you are not using mocha as your test runner, it is recommended to use chai-jest-snapshot in "framework-agnostic configuration mode".
 

--- a/src/buildMatchSnapshot.js
+++ b/src/buildMatchSnapshot.js
@@ -4,7 +4,7 @@ import { SnapshotState } from "jest-snapshot";
 
 const buildMatchSnapshot = (utils, parseArgs) => {
   return function matchSnapshot(...args) {
-    const { snapshotFilename, snapshotName, update } = parseArgs(args);
+    const { snapshotFilename, snapshotName, update, ci } = parseArgs(args);
 
     if (utils.flag(this, 'negate')) {
       throw new Error("`matchSnapshot` cannot be used with `.not`.");
@@ -12,9 +12,9 @@ const buildMatchSnapshot = (utils, parseArgs) => {
 
     const obj = this._obj;
     const absolutePathToSnapshot = path.resolve(snapshotFilename);
-
+    
     const snapshotState = new SnapshotState(undefined, {
-      updateSnapshot: update ? "all" : "new",
+      updateSnapshot: ci ? "none" : (update ? "all" : "new"),
       snapshotPath: absolutePathToSnapshot,
     });
 

--- a/src/buildMatchSnapshot.js
+++ b/src/buildMatchSnapshot.js
@@ -12,7 +12,6 @@ const buildMatchSnapshot = (utils, parseArgs) => {
 
     const obj = this._obj;
     const absolutePathToSnapshot = path.resolve(snapshotFilename);
-    
     const snapshotState = new SnapshotState(undefined, {
       updateSnapshot: ci ? "none" : (update ? "all" : "new"),
       snapshotPath: absolutePathToSnapshot,

--- a/src/determineConfig.js
+++ b/src/determineConfig.js
@@ -2,6 +2,7 @@ module.exports = function determineConfig(args, config, getNameForSnapshotUsingT
   let snapshotFilename;
   let snapshotName;
   let update;
+  let ci = false;
 
   if (config.snapshotFilename && !config.snapshotNameTemplate) {
     throw new Error("Using `setFilename` without also using `setTestName` is not supported.");
@@ -36,9 +37,14 @@ module.exports = function determineConfig(args, config, getNameForSnapshotUsingT
     update = true;
   }
 
+  if (typeof process !== "undefined" && process.env && process.env.CHAI_JEST_CI) {
+    ci = true;
+  }
+
   return {
     snapshotFilename,
     snapshotName,
     update,
+    ci
   };
 }

--- a/src/determineConfig.js
+++ b/src/determineConfig.js
@@ -37,7 +37,7 @@ module.exports = function determineConfig(args, config, getNameForSnapshotUsingT
     update = true;
   }
 
-  if (typeof process !== "undefined" && process.env && process.env.CHAI_JEST_CI) {
+  if (typeof process !== "undefined" && process.env && process.env.CI) {
     ci = true;
   }
 

--- a/src/spec/determineConfig.spec.js
+++ b/src/spec/determineConfig.spec.js
@@ -9,66 +9,78 @@ describe("determineConfig", function() {
       {
         args: [],
         config: {},
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [],
         config: {},
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [true],
         config: {},
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [false],
         config: {},
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: false,
         expected: Error,
       },
       // Normal cases when not using config
       {
         args: ["filename", "name"],
         config: {},
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: {
           snapshotFilename: "filename",
           snapshotName: "name",
           update: false,
+          ci: false
         },
       },
       {
         args: ["filename", "name"],
         config: {},
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: false,
         expected: {
           snapshotFilename: "filename",
           snapshotName: "name",
           update: true,
+          ci: false
         },
       },
       {
         args: ["filename", "name", true],
         config: {},
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: {
           snapshotFilename: "filename",
           snapshotName: "name",
           update: true,
+          ci: false
         },
       },
       {
         args: ["filename", "name", true],
         config: {},
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: false,
         expected: {
           snapshotFilename: "filename",
           snapshotName: "name",
           update: true,
+          ci: false
         },
       },
       // Invalid configuration cases
@@ -76,50 +88,58 @@ describe("determineConfig", function() {
       {
         args: [],
         config: { snapshotFilename: "filename" },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [],
         config: { snapshotFilename: "filename" },
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [true],
         config: { snapshotFilename: "filename" },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [false],
         config: { snapshotFilename: "filename" },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       // * snapshot name determined but not filename
       {
         args: [],
         config: { snapshotName: "name" },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [],
         config: { snapshotName: "name" },
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [true],
         config: { snapshotName: "name" },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       {
         args: [false],
         config: { snapshotName: "name" },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: Error,
       },
       // valid cases using configuration
@@ -129,11 +149,13 @@ describe("determineConfig", function() {
           snapshotFilename: "filename",
           snapshotNameTemplate: "name",
         },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: {
           snapshotFilename: "filename",
           snapshotName: getNameForSnapshotUsingTemplate("filename", "name"),
           update: false,
+          ci: false
         },
       },
       {
@@ -142,11 +164,13 @@ describe("determineConfig", function() {
           snapshotFilename: "filename",
           snapshotNameTemplate: "name",
         },
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: false,
         expected: {
           snapshotFilename: "filename",
           snapshotName: getNameForSnapshotUsingTemplate("filename", "name"),
           update: true,
+          ci: false
         },
       },
       {
@@ -155,11 +179,13 @@ describe("determineConfig", function() {
           snapshotFilename: "filename",
           snapshotNameTemplate: "name",
         },
-        envFlag: false,
+        envUpdateFlag: false,
+        envCiFlag: false,
         expected: {
           snapshotFilename: "filename",
           snapshotName: getNameForSnapshotUsingTemplate("filename", "name"),
           update: true,
+          ci: false
         },
       },
       {
@@ -168,11 +194,13 @@ describe("determineConfig", function() {
           snapshotFilename: "filename",
           snapshotNameTemplate: "name",
         },
-        envFlag: true,
+        envUpdateFlag: true,
+        envCiFlag: true,
         expected: {
           snapshotFilename: "filename",
           snapshotName: getNameForSnapshotUsingTemplate("filename", "name"),
           update: true,
+          ci: true
         },
       },
     ];
@@ -181,13 +209,17 @@ describe("determineConfig", function() {
       describe(
         `when args is ${JSON.stringify(example.args)} ` +
         `and config is ${JSON.stringify(example.config)} ` +
-        `and CHAI_JEST_SNAPSHOT_UPDATE_ALL is ${example.envFlag ? "set" : "not set"}`
+        `and CHAI_JEST_SNAPSHOT_UPDATE_ALL is ${example.envUpdateFlag ? "set" : "not set"} `+
+        `and CHAI_JEST_CI is ${example.envCiFlag ? "set" : "not set"}`
       , function() {
 
         const run = () => {
           delete process.env.CHAI_JEST_SNAPSHOT_UPDATE_ALL;
-          if (example.envFlag) {
+          if (example.envUpdateFlag) {
             process.env.CHAI_JEST_SNAPSHOT_UPDATE_ALL = "true";
+          }
+          if (example.envCiFlag) {
+            process.env.CHAI_JEST_CI = "true";
           }
           return determineConfig(example.args, example.config, getNameForSnapshotUsingTemplate);
         };
@@ -203,6 +235,7 @@ describe("determineConfig", function() {
             expect(actual.snapshotFilename).to.equal(expected.snapshotFilename);
             expect(actual.snapshotName).to.equal(expected.snapshotName);
             expect(actual.update).to.equal(expected.update);
+            expect(actual.ci).to.equal(expected.ci);
           });
         }
       });

--- a/src/spec/determineConfig.spec.js
+++ b/src/spec/determineConfig.spec.js
@@ -174,6 +174,21 @@ describe("determineConfig", function() {
         },
       },
       {
+        args: [],
+        config: {
+          snapshotFilename: "filename",
+          snapshotNameTemplate: "name",
+        },
+        envUpdateFlag: false,
+        envCiFlag: true,
+        expected: {
+          snapshotFilename: "filename",
+          snapshotName: getNameForSnapshotUsingTemplate("filename", "name"),
+          update: false,
+          ci: true
+        },
+      },
+      {
         args: [true],
         config: {
           snapshotFilename: "filename",
@@ -210,16 +225,17 @@ describe("determineConfig", function() {
         `when args is ${JSON.stringify(example.args)} ` +
         `and config is ${JSON.stringify(example.config)} ` +
         `and CHAI_JEST_SNAPSHOT_UPDATE_ALL is ${example.envUpdateFlag ? "set" : "not set"} `+
-        `and CHAI_JEST_CI is ${example.envCiFlag ? "set" : "not set"}`
+        `and CI is ${example.envCliFlag ? "set" : "not set"}`
       , function() {
 
         const run = () => {
           delete process.env.CHAI_JEST_SNAPSHOT_UPDATE_ALL;
+          delete process.env.CI;
           if (example.envUpdateFlag) {
             process.env.CHAI_JEST_SNAPSHOT_UPDATE_ALL = "true";
           }
           if (example.envCiFlag) {
-            process.env.CHAI_JEST_CI = "true";
+            process.env.CI = "true";
           }
           return determineConfig(example.args, example.config, getNameForSnapshotUsingTemplate);
         };


### PR DESCRIPTION
* Add a check for the CI environment variable to determineConfig and return it as a property in the returned object from that function
* Destructure this property in buildMatchSnapshot and when it is true, pass updateSnapshot as "none" to the SnapshotState constructor: buildMatchSnapshot
* Expand the determineConfig spec to check for the ci flag

See #18 for details