### PR TITLE
Added default values for actual and expected string values

### DIFF
--- a/src/buildMatchSnapshot.js
+++ b/src/buildMatchSnapshot.js
@@ -17,15 +17,13 @@ const buildMatchSnapshot = (utils, parseArgs) => {
       snapshotPath: absolutePathToSnapshot,
     });
 
-    const {
-      actual,
-      expected,
-      pass,
-    } = snapshotState.match(snapshotName, obj, snapshotName);
+    const match = snapshotState.match(snapshotName, obj, snapshotName);
+    actual = match.actual || "";
+    expected = match.expected || "";
     snapshotState.save();
 
     this.assert(
-      pass,
+      match.pass,
       `expected value to match snapshot ${snapshotName}`,
       `expected value to not match snapshot ${snapshotName}`,
       expected.trim(),


### PR DESCRIPTION
With the introduction of the `CI` flag (#20) the actual value might be undefined in some cases and will have an error that `trim` does not exist on undefined. Added default values to prevent this.