### PR TITLE
Fix: Added const to the new variables

### DIFF
--- a/src/buildMatchSnapshot.js
+++ b/src/buildMatchSnapshot.js
@@ -18,8 +18,8 @@ const buildMatchSnapshot = (utils, parseArgs) => {
     });
 
     const match = snapshotState.match(snapshotName, obj, snapshotName);
-    actual = match.actual || "";
-    expected = match.expected || "";
+    const actual = match.actual || "";
+    const expected = match.expected || "";
     snapshotState.save();
 
     this.assert(


### PR DESCRIPTION
Fixes https://github.com/suchipi/chai-jest-snapshot/issues/22

`actual` and `expected` variables were used without being defined. It was causing the `ReferenceError: actual is not defined` error.